### PR TITLE
I wanna use Mouse instead of Moose.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,8 +3,9 @@ name 'AnyMQ';
 all_from 'lib/AnyMQ.pm';
 readme_from 'lib/AnyMQ.pm';
 build_requires 'Test::More';
-requires 'Moose' => '0.99';
-requires 'MooseX::Traits';
+requires 'Any::Moose';
+requires 'MouseX::Traits';
+requires 'MouseX::NativeTraits';
 requires 'AnyEvent';
 test_requires 'Test::Requires';
 

--- a/lib/AnyMQ.pm
+++ b/lib/AnyMQ.pm
@@ -4,11 +4,11 @@ use 5.008_001;
 our $VERSION = '0.31';
 
 use AnyEvent;
-use Moose;
+use Any::Moose;
 use AnyMQ::Topic;
 use AnyMQ::Queue;
 
-with 'MooseX::Traits';
+with any_moose("X::Traits");
 
 has '+_trait_namespace' => (default => 'AnyMQ::Trait');
 
@@ -51,7 +51,7 @@ sub new_listener {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;
 
 __END__

--- a/lib/AnyMQ/Queue.pm
+++ b/lib/AnyMQ/Queue.pm
@@ -1,5 +1,5 @@
 package AnyMQ::Queue;
-use Moose;
+use Any::Moose;
 use AnyEvent;
 use Try::Tiny;
 use Scalar::Util qw(weaken refaddr);
@@ -117,7 +117,7 @@ sub poll {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;
 
 __END__

--- a/lib/AnyMQ/Topic.pm
+++ b/lib/AnyMQ/Topic.pm
@@ -5,12 +5,12 @@ use 5.008_001;
 our $VERSION = '0.01';
 
 use AnyEvent;
-use Moose;
+use Any::Moose;
 use Try::Tiny;
 use Scalar::Util;
 use Time::HiRes;
 
-with 'MooseX::Traits';
+with any_moose("X::Traits");
 
 has name => (is => 'rw', isa => 'Str');
 has bus => (is => "ro", isa => "AnyMQ", weak_ref => 1);
@@ -73,7 +73,7 @@ sub remove_subscriber {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Moose;
+no Any::Moose;
 1;
 
 =encoding utf-8

--- a/lib/AnyMQ/Topic/Trait/WithBacklog.pm
+++ b/lib/AnyMQ/Topic/Trait/WithBacklog.pm
@@ -1,5 +1,5 @@
 package AnyMQ::Topic::Trait::WithBacklog;
-use Moose::Role;
+use Any::Moose "::Role";
 
 has backlog_length => (is => "rw", isa => "Int", default => sub { 30 });
 has backlog => (is => 'rw', isa => 'ArrayRef', default => sub { [] });

--- a/t/trait.t
+++ b/t/trait.t
@@ -5,7 +5,7 @@ use AnyMQ;
 our ($built, $demolished) = (0, 0);
 {
     package AnyMQ::Trait::Test;
-    use Moose::Role;
+    use Any::Moose "::Role";
     use Test::More;
 
     sub BUILD {}; after 'BUILD' => sub {


### PR DESCRIPTION
Since @ _ gfx _  released MouseX::Traits, AnyMQ can depend on not Moose directly but Any::Moose (and Mouse).

I prefer Mouse rather than Moose because Mouse is launched faster :)
