### PR TITLE
Add ->unpoll method

### DIFF
--- a/lib/AnyMQ/Queue.pm
+++ b/lib/AnyMQ/Queue.pm
@@ -119,6 +119,13 @@ sub poll {
         if @{ $self->{buffer} };
 }
 
+sub unpoll {
+    my $self = shift;
+    $self->cv->cb(undef);
+    $self->persistent(0);
+    $self->{timer} = $self->_reaper;
+}
+
 __PACKAGE__->meta->make_immutable;
 no Any::Moose;
 1;
@@ -165,6 +172,11 @@ Subscribe to a L<AnyMQ::Topic> object.
 
 This is the event-driven poll mechanism, which accepts a callback.
 Messages are streamed to C<$code_ref> passed in.
+
+=head2 unpoll
+
+Cancels a running L</poll>, which will result in L</on_timeout> being
+called.
 
 =head2 poll_once($code_ref, $timeout)
 


### PR DESCRIPTION
You referenced wanting an ->unpoll in Web::Hippie, and it was indeed generally useful elsewhere.
