### PR TITLE
Bumped version to force creation of new distribution

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension AnyMQ
 
+0.36 Sun Feb 22 21:13:00 EST 2015
+        - Bump version to force a rebuild of the distribution with updated 
+          Module::Install files to fix version problem causing test failures
+          [herveus]
+
 0.35 Sat Feb 16 18:34:24 CST 2013
         - Support unpoll. [alexmv]
 

--- a/lib/AnyMQ.pm
+++ b/lib/AnyMQ.pm
@@ -1,7 +1,7 @@
 package AnyMQ;
 use strict;
 use 5.008_001;
-our $VERSION = '0.35';
+our $VERSION = '0.36';
 
 use AnyEvent;
 use Any::Moose;


### PR DESCRIPTION
This updates the files in inc for Module::Starter which should
clear up the string of test failures on Test::Builder::Module being
too low of a version (wants 0.99, getting 0.98).