### PR TITLE
Convert from Any::Moose to Moo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 before_install:
-  - "cpanm Module::Install::ReadmeFromPod Module::Install::Any::Moose Test::Requires Module::Install::Repository"
-
-env:
-  - ANY_MOOSE=Moose
-  - ANY_MOOSE=Mouse
+  - "cpanm Module::Install::ReadmeFromPod Test::Requires Module::Install::Repository"
 
 language: perl
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 before_install:
   - "cpanm Module::Install::ReadmeFromPod Test::Requires Module::Install::Repository"
-
 language: perl
 perl:
-  - "5.14"
+  - "5.20"
+  - "5.18"
   - "5.16"
+  - "5.14"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - "cpanm Module::Install::ReadmeFromPod Test::Requires Module::Install::Repository"
+  - "cpanm Module::Install::ReadmeFromPod Test::Requires Module::Install::Repository Test::Memory::Cycle"
 language: perl
 perl:
   - "5.20"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,14 +3,12 @@ name 'AnyMQ';
 all_from 'lib/AnyMQ.pm';
 readme_from 'lib/AnyMQ.pm';
 build_requires 'Test::More';
-requires 'Any::Moose';
-requires 'MouseX::NativeTraits';
-requires 'AnyEvent';
 
-if (my $moose = $ENV{ANY_MOOSE}) {
-    requires $moose.'X::Traits';
-}
-requires_any_moose 'X::Traits';
+requires 'Moo', '2';
+requires 'MooX::Traits';
+requires 'MooX::HandlesVia';
+requires 'Types::Standard';
+requires 'AnyEvent';
 
 test_requires 'Test::Requires';
 

--- a/lib/AnyMQ.pm
+++ b/lib/AnyMQ.pm
@@ -4,15 +4,17 @@ use 5.008_001;
 our $VERSION = '0.35';
 
 use AnyEvent;
-use Any::Moose;
+use Moo 2;
+use Types::Standard qw< :types >;
 use AnyMQ::Topic;
 use AnyMQ::Queue;
+use namespace::clean;
 
-with any_moose("X::Traits");
+with "MooX::Traits";
 
-has '+_trait_namespace' => (default => 'AnyMQ::Trait');
+sub _trait_namespace { 'AnyMQ::Trait' }
 
-has topics => (is => "ro", isa => "HashRef[AnyMQ::Topic]",
+has topics => (is => "ro", isa => HashRef[InstanceOf['AnyMQ::Topic']],
                default => sub { {} });
 
 my $DEFAULT_BUS;
@@ -50,8 +52,6 @@ sub new_listener {
     return $listener;
 }
 
-__PACKAGE__->meta->make_immutable;
-no Any::Moose;
 1;
 
 __END__

--- a/lib/AnyMQ/Queue.pm
+++ b/lib/AnyMQ/Queue.pm
@@ -1,20 +1,22 @@
 package AnyMQ::Queue;
 use strict;
-use Any::Moose;
+use Moo 2;
+use Types::Standard qw< :types >;
 use AnyEvent;
 use Try::Tiny;
 use Scalar::Util qw(weaken refaddr);
 use Time::HiRes;
+use namespace::clean;
 use constant DEBUG => 0;
 
-has id => (is => 'rw', isa => 'Str');
-has persistent => (is => "rw", isa => "Bool", default => sub { 0 });
-has buffer => (is => "ro", isa => "ArrayRef", default => sub { [] });
-has cv => (is => "rw", isa => "AnyEvent::CondVar", default => sub { AE::cv });
-has destroyed => (is => "rw", isa => "Bool", default => sub { 0 });
+has id => (is => 'rw', isa => Str);
+has persistent => (is => "rw", isa => Bool, default => sub { 0 });
+has buffer => (is => "ro", isa => ArrayRef, default => sub { [] });
+has cv => (is => "rw", isa => InstanceOf["AnyEvent::CondVar"], default => sub { AE::cv });
+has destroyed => (is => "rw", isa => Bool, default => sub { 0 });
 has on_timeout => (is => "rw");
 has on_error  => (is => "rw");
-has timeout => (is => "rw", isa => "Int", default => sub { 55 });
+has timeout => (is => "rw", isa => Int, default => sub { 55 });
 
 sub BUILD {
     my $self = shift;
@@ -127,8 +129,6 @@ sub unpoll {
     $self->{timer} = $self->_reaper;
 }
 
-__PACKAGE__->meta->make_immutable;
-no Any::Moose;
 1;
 
 __END__

--- a/lib/AnyMQ/Topic/Trait/WithBacklog.pm
+++ b/lib/AnyMQ/Topic/Trait/WithBacklog.pm
@@ -1,9 +1,11 @@
 package AnyMQ::Topic::Trait::WithBacklog;
 use strict;
-use Any::Moose "::Role";
+use Moo::Role 2;
+use Types::Standard qw< :types >;
+use namespace::clean;
 
-has backlog_length => (is => "rw", isa => "Int", default => sub { 30 });
-has backlog => (is => 'rw', isa => 'ArrayRef', default => sub { [] });
+has backlog_length => (is => "rw", isa => Int, default => sub { 30 });
+has backlog => (is => 'rw', isa => ArrayRef, default => sub { [] });
 
 sub backlog_events {
     my $self = shift;

--- a/t/trait.t
+++ b/t/trait.t
@@ -5,7 +5,7 @@ use AnyMQ;
 our ($built, $demolished) = (0, 0);
 {
     package AnyMQ::Trait::Test;
-    use Any::Moose "::Role";
+    use Moo::Role;
     use Test::More;
 
     sub BUILD {}; after 'BUILD' => sub {


### PR DESCRIPTION
Any::Moose is deprecated, for good reason!

Note that `t/cycle.t` fails on master for me (didn't dig into it) and it continues to fail in this PR for me too.

Closes #4.
